### PR TITLE
redesign stord client code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LIBRARY_LIST
 	event
 	double-conversion
 	iberty
+	atomic
 	${ThriftLibs}
 )
 

--- a/src/include/TgtInterface.h
+++ b/src/include/TgtInterface.h
@@ -17,7 +17,7 @@ int32_t HycOpenVmdk(const char* vmid, const char* vmdkid, int eventfd,
 int32_t HycCloseVmdk(VmdkHandle handle);
 RequestID HycScheduleRead(VmdkHandle handle, const void* privatep,
 		char* bufferp, int32_t buf_sz, int64_t offset);
-uint32_t HycGetCompleteRequests(VmdkHandle handle, RequestResult *resultsp,
+uint32_t HycGetCompleteRequests(VmdkHandle handle, struct RequestResult *resultsp,
 		uint32_t nresults, bool *has_morep);
 RequestID HycScheduleWrite(VmdkHandle handle, const void* privatep,
 		char* bufferp, int32_t buf_sz, int64_t offset);

--- a/src/include/TgtInterface.h
+++ b/src/include/TgtInterface.h
@@ -10,18 +10,18 @@ extern "C"  {
 #endif
 
 void HycStorInitialize(int argc, char *argv[], char *stord_ip, uint16_t stord_port);
-RpcConnectHandle HycStorRpcServerConnect(void);
-int32_t HycStorRpcServerDisconnect(RpcConnectHandle handle);
-int32_t HycOpenVmdk(RpcConnectHandle handle, const char* vmid, const char* vmdkid,
-		int eventfd);
-int32_t HycCloseVmdk(RpcConnectHandle handle);
-RequestID HycScheduleRead(RpcConnectHandle handle, const void* privatep,
+int32_t HycStorRpcServerConnect(void);
+int32_t HycStorRpcServerDisconnect(void);
+int32_t HycOpenVmdk(const char* vmid, const char* vmdkid, int eventfd,
+		VmdkHandle* handlep);
+int32_t HycCloseVmdk(VmdkHandle handle);
+RequestID HycScheduleRead(VmdkHandle handle, const void* privatep,
 		char* bufferp, int32_t buf_sz, int64_t offset);
-uint32_t HycGetCompleteRequests(RpcConnectHandle handle, struct RequestResult *resultsp,
+uint32_t HycGetCompleteRequests(VmdkHandle handle, RequestResult *resultsp,
 		uint32_t nresults, bool *has_morep);
-RequestID HycScheduleWrite(RpcConnectHandle handle, const void* privatep,
+RequestID HycScheduleWrite(VmdkHandle handle, const void* privatep,
 		char* bufferp, int32_t buf_sz, int64_t offset);
-RequestID HycScheduleWriteSame(RpcConnectHandle handle, const void* privatep,
+RequestID HycScheduleWriteSame(VmdkHandle handle, const void* privatep,
 		char* bufferp, int32_t buf_sz, int32_t write_sz, int64_t offset);
 
 #ifdef __cplusplus

--- a/src/include/TgtTypes.h
+++ b/src/include/TgtTypes.h
@@ -8,7 +8,6 @@ extern "C"  {
 #define kInvalidVmHandle   0
 #define kInvalidVmdkHandle 0
 #define kInvalidRequestID  0
-#define kInvalidRpcHandle  0
 
 #ifndef hyc_likely
 #define hyc_likely(x) (__builtin_expect(!!(x), 1))
@@ -21,7 +20,6 @@ extern "C"  {
 typedef int64_t RequestID;
 typedef int64_t VmHandle;
 typedef int64_t VmdkHandle;
-typedef int64_t RpcConnectHandle;
 
 struct RequestResult {
 	const void* privatep;

--- a/src/include/Utils.h
+++ b/src/include/Utils.h
@@ -16,4 +16,18 @@ void MoveLastElements(std::vector<T>& dst, std::vector<T>& src, size_t tomove) {
 	src.erase(sit, eit);
 }
 
+namespace os {
+
+unsigned int NumberOfCpus(void) {
+	return std::thread::hardware_concurrency();
+}
+
+int GetCurCpuCore(void) {
+	auto core = sched_getcpu();
+	if (core < 0) {
+		return -1;
+	}
+	return core;
+}
+}
 }

--- a/src/thrift-client/TgtInterfaceImpl.cpp
+++ b/src/thrift-client/TgtInterfaceImpl.cpp
@@ -399,6 +399,8 @@ StordConnection* StordRpc::GetStordConnection() const noexcept {
 		return GetStordConnectionCpu();
 	case StordRpc::SchedulePolicy::kStatic:
 		return GetStordConnectionRR();
+	default:
+		return nullptr;
 	}
 }
 


### PR DESCRIPTION

TGTD executes SCSI commands in single thread, as far as possible
we should relieve main thread from STORD client side processing.

1. At the moment, we create a thread from every LUN (or VMDK)
instead create #cores/2 threads in stord client, each thread is bound
to different CPU core. Assuming STORD is also running on same 
machine, assign #cores/2 threads to STORD.

2. A single StorRpcAsyncClient is associated with each thread

3. When a Lun is added (during OpenVmdk), pick a single StorRpcAsyncClient from
pool and associate it with StordVmdk. Every RPC request from StordVmdk uses the
same RPC client.

4. When TGTD receives SCSI command, TGTD gives the command to library to send
RPC request. At the moment, the RPC request is scheduled immediately, however
we can bunch together multiple SCSI commands instead. This relieves main thread
of TGTD.

5. When STORD responds back with completion of RPC request. We have choice to
complete request immediately. However instead bunch together multiple complete
IOs before posting command completions. This relieves main CPU thread of TGTD.

Numbers with these changes

**8 Disks**
```
Write - 32.7K IOPS (combined)
      - CPU consumption of main thread - 75%
        - TGTD
          - main thread - 75%
          - other 4 threads - 28 - 32
        - STORD - 300%

Read - 31.1K IOPS (combined)
      - CPU consumption of main thread - 75%
        - TGTD
          - main thread - 75%
          - other 4 threads - 30 - 36
        - STORD - 300%
```

**4 Disks**
```
Write - 32.8K IOPS (combined)
      - CPU consumption of main thread - 75%
        - TGTD
          - main thread - 75%
          - other 4 threads - 22 - 30
        - STORD - 300%

Read - 29.8K IOPS (combined)
      - CPU consumption of main thread - 75%
        - TGTD
          - main thread - 75%
          - other 4 threads - 28 - 34
        - STORD - 300%

```