### PR TITLE
Pass StordVmdk pointer as handle to library client

### DIFF
--- a/src/include/TgtTypes.h
+++ b/src/include/TgtTypes.h
@@ -19,7 +19,7 @@ extern "C"  {
 
 typedef int64_t RequestID;
 typedef int64_t VmHandle;
-typedef int64_t VmdkHandle;
+typedef void* VmdkHandle;
 
 struct RequestResult {
 	const void* privatep;

--- a/src/thrift-client/TgtInterfaceImpl.cpp
+++ b/src/thrift-client/TgtInterfaceImpl.cpp
@@ -295,6 +295,13 @@ void StordConnection::SetThreadAffinity(uint16_t cpu, std::thread* threadp) {
 	} else {
 		LOG(ERROR) << "Thread " << handle << " bound to CPU " << cpu;
 	}
+
+	std::string name("StordClient");
+	name += std::to_string(cpu);
+	rc = pthread_setname_np(handle, name.c_str());
+	if (hyc_unlikely(rc < 0)) {
+		LOG(ERROR) << "Setting thread name failed";
+	}
 }
 
 void StordConnection::SetPingTimeout() {
@@ -442,7 +449,7 @@ public:
 	uint32_t GetCompleteRequests(RequestResult* resultsp, uint32_t nresults,
 		bool *has_morep);
 
-	VmdkHandle GetHandle() const noexcept;
+	::hyc_thrift::VmdkHandle GetHandle() const noexcept;
 	const std::string& GetVmdkId() const noexcept;
 
 	friend std::ostream& operator << (std::ostream& os, const StordVmdk& vmdk);
@@ -467,7 +474,7 @@ private:
 private:
 	std::string vmid_;
 	std::string vmdkid_;
-	VmdkHandle vmdk_handle_{kInvalidVmdkHandle};
+	::hyc_thrift::VmdkHandle vmdk_handle_{kInvalidVmdkHandle};
 	int eventfd_{-1};
 	StordConnection* connectp_{nullptr};
 
@@ -502,7 +509,7 @@ StordVmdk::~StordVmdk() {
 	CloseVmdk();
 }
 
-VmdkHandle StordVmdk::GetHandle() const noexcept {
+::hyc_thrift::VmdkHandle StordVmdk::GetHandle() const noexcept {
 	return vmdk_handle_;
 }
 
@@ -561,6 +568,8 @@ std::pair<Request*, bool> StordVmdk::NewRequest(Request::Type type,
 		return std::make_pair(nullptr, false);
 	}
 
+	++stats_.pending_;
+
 	request->id = ++requestid_;
 	request->type = type;
 	request->privatep = privatep;
@@ -574,7 +583,6 @@ std::pair<Request*, bool> StordVmdk::NewRequest(Request::Type type,
 	auto empty = requests_.scheduled_.empty();
 	requests_.scheduled_.emplace(request->id, std::move(request));
 	requests_.pending_.emplace_back(reqp);
-	++stats_.pending_;
 	return std::make_pair(reqp, empty);
 }
 
@@ -835,18 +843,18 @@ public:
 	int32_t Connect(uint32_t ping_secs = 30);
 	int32_t Disconnect(bool force = false);
 	int32_t OpenVmdk(const char* vmid, const char* vmdkid, int eventfd,
-		VmdkHandle* handlep);
-	int32_t CloseVmdk(VmdkHandle handle);
-	RequestID VmdkRead(VmdkHandle handle, const void* privatep, char* bufferp,
+		StordVmdk** vmdkpp);
+	int32_t CloseVmdk(StordVmdk* vmdkp);
+	RequestID VmdkRead(StordVmdk* vmdkp, const void* privatep, char* bufferp,
 		int32_t buf_sz, int64_t offset);
-	uint32_t VmdkGetCompleteRequest(VmdkHandle handle, RequestResult* resultsp,
+	uint32_t VmdkGetCompleteRequest(StordVmdk* vmdkp, RequestResult* resultsp,
 		uint32_t nresults, bool *has_morep);
-	RequestID VmdkWrite(VmdkHandle handle, const void* privatep, char* bufferp,
+	RequestID VmdkWrite(StordVmdk* vmdkp, const void* privatep, char* bufferp,
 		int32_t buf_sz, int64_t offset);
-	RequestID VmdkWriteSame(VmdkHandle handle, const void* privatep,
+	RequestID VmdkWriteSame(StordVmdk* vmdkp, const void* privatep,
 		char* bufferp, int32_t buf_sz, int32_t write_sz, int64_t offset);
 private:
-	StordVmdk* FindVmdk(VmdkHandle handle);
+	StordVmdk* FindVmdk(::hyc_thrift::VmdkHandle handle);
 	StordVmdk* FindVmdk(const std::string& vmdkid);
 private:
 	struct {
@@ -856,7 +864,6 @@ private:
 	struct {
 		mutable std::mutex mutex_;
 		std::unordered_map<std::string, std::unique_ptr<StordVmdk>> ids_;
-		std::unordered_map<VmdkHandle, StordVmdk*> handles_;
 	} vmdk_;
 };
 
@@ -896,19 +903,8 @@ int32_t Stord::Disconnect(bool force) {
 			return -EBUSY;
 		}
 	}
-	vmdk_.handles_.clear();
 	stord_.rpc_ = nullptr;
 	return 0;
-}
-
-StordVmdk* Stord::FindVmdk(VmdkHandle handle) {
-	std::lock_guard<std::mutex> lock(vmdk_.mutex_);
-	auto it = vmdk_.handles_.find(handle);
-	if (hyc_unlikely(it == vmdk_.handles_.end())) {
-		return nullptr;
-	}
-
-	return it->second;
 }
 
 StordVmdk* Stord::FindVmdk(const std::string& vmdkid) {
@@ -922,8 +918,8 @@ StordVmdk* Stord::FindVmdk(const std::string& vmdkid) {
 }
 
 int32_t Stord::OpenVmdk(const char* vmid, const char* vmdkid, int eventfd,
-		VmdkHandle* handlep) {
-	*handlep = kInvalidVmdkHandle;
+		StordVmdk** vmdkpp) {
+	*vmdkpp = nullptr;
 	auto vmdkp = FindVmdk(vmdkid);
 	if (hyc_unlikely(vmdkp)) {
 		return -EEXIST;
@@ -944,84 +940,46 @@ int32_t Stord::OpenVmdk(const char* vmid, const char* vmdkid, int eventfd,
 		return rc;
 	}
 
-	*handlep = vmdkp->GetHandle();
+	*vmdkpp = vmdkp;
 	std::lock_guard<std::mutex> lock(vmdk_.mutex_);
 	vmdk_.ids_.emplace(vmdkid, std::move(vmdk));
-	try {
-		vmdk_.handles_.emplace(*handlep, vmdkp);
-	} catch (...) {
-		auto it = vmdk_.ids_.find(vmdkp->GetVmdkId());
-		vmdk_.ids_.erase(it);
-		throw;
-	}
 	return 0;
 }
 
-int32_t Stord::CloseVmdk(VmdkHandle handle) {
+int32_t Stord::CloseVmdk(StordVmdk* vmdkp) {
+	const auto& id = vmdkp->GetVmdkId();
+
 	std::unique_lock<std::mutex> lock(vmdk_.mutex_);
-	auto hit = vmdk_.handles_.find(handle);
-	if (hyc_unlikely(hit == vmdk_.handles_.end())) {
+	auto it = vmdk_.ids_.find(id);
+	if (hyc_unlikely(it == vmdk_.ids_.end())) {
 		return -ENODEV;
 	}
 
-	auto vmdkp = hit->second;
-	const auto& id = vmdkp->GetVmdkId();
-
-	auto iit = vmdk_.ids_.find(id);
-	log_assert(iit != vmdk_.ids_.end());
-
-	auto vmdk = std::move(iit->second);
-	try {
-		vmdk_.ids_.erase(iit);
-	} catch (...) {
-		iit->second = std::move(vmdk);
-		throw;
-	}
-	vmdk_.handles_.erase(hit);
+	auto vmdk = std::move(it->second);
+	vmdk_.ids_.erase(it);
 	lock.unlock();
 
 	vmdk->CloseVmdk();
 	return 0;
 }
 
-RequestID Stord::VmdkRead(VmdkHandle handle, const void* privatep,
+RequestID Stord::VmdkRead(StordVmdk* vmdkp, const void* privatep,
 		char* bufferp, int32_t buf_sz, int64_t offset) {
-	auto vmdkp = FindVmdk(handle);
-	if (hyc_unlikely(not vmdkp)) {
-		return kInvalidRequestID;
-	}
-
 	return vmdkp->ScheduleRead(privatep, bufferp, buf_sz, offset);
 }
 
-uint32_t Stord::VmdkGetCompleteRequest(VmdkHandle handle,
+uint32_t Stord::VmdkGetCompleteRequest(StordVmdk* vmdkp,
 		RequestResult* resultsp, uint32_t nresults, bool *has_morep) {
-	auto vmdkp = FindVmdk(handle);
-	if (hyc_unlikely(not vmdkp)) {
-		*has_morep = false;
-		return 0;
-	}
-
 	return vmdkp->GetCompleteRequests(resultsp, nresults, has_morep);
 }
 
-RequestID Stord::VmdkWrite(VmdkHandle handle, const void* privatep,
+RequestID Stord::VmdkWrite(StordVmdk* vmdkp, const void* privatep,
 		char* bufferp, int32_t buf_sz, int64_t offset) {
-	auto vmdkp = FindVmdk(handle);
-	if (hyc_unlikely(not vmdkp)) {
-		return kInvalidRequestID;
-	}
-
 	return vmdkp->ScheduleWrite(privatep, bufferp, buf_sz, offset);
 }
 
-RequestID Stord::VmdkWriteSame(VmdkHandle handle, const void* privatep,
+RequestID Stord::VmdkWriteSame(StordVmdk* vmdkp, const void* privatep,
 		char* bufferp, int32_t buf_sz, int32_t write_sz, int64_t offset) {
-	auto vmdkp = FindVmdk(handle);
-	if (hyc_unlikely(not vmdkp)) {
-		return kInvalidRequestID;
-	}
-
 	return vmdkp->ScheduleWriteSame(privatep, bufferp, buf_sz, write_sz, offset);
 }
 
@@ -1069,17 +1027,24 @@ int32_t HycStorRpcServerDisconnect(void) {
 int32_t HycOpenVmdk(const char* vmid, const char* vmdkid, int eventfd,
 		VmdkHandle* handlep) {
 	log_assert(vmid != nullptr and vmdkid != nullptr and handlep);
+	*handlep = nullptr;
 	try {
-		return g_stord.OpenVmdk(vmid, vmdkid, eventfd, handlep);
+		::hyc::StordVmdk* vmdkp;
+		auto rc = g_stord.OpenVmdk(vmid, vmdkid, eventfd, &vmdkp);
+		if (hyc_unlikely(rc < 0)) {
+			return rc;
+		}
+		*handlep = reinterpret_cast<VmdkHandle>(vmdkp);
+		return rc;
 	} catch (std::exception& e) {
-		*handlep = kInvalidVmdkHandle;
 		return -ENODEV;
 	}
 }
 
 int32_t HycCloseVmdk(VmdkHandle handle) {
 	try {
-		return g_stord.CloseVmdk(handle);
+		auto vmdkp = reinterpret_cast<::hyc::StordVmdk*>(handle);
+		return g_stord.CloseVmdk(vmdkp);
 	} catch (std::exception& e) {
 		return -ENODEV;
 	}
@@ -1088,7 +1053,8 @@ int32_t HycCloseVmdk(VmdkHandle handle) {
 RequestID HycScheduleRead(VmdkHandle handle, const void* privatep,
 		char* bufferp, int32_t buf_sz, int64_t offset) {
 	try {
-		return g_stord.VmdkRead(handle, privatep, bufferp, buf_sz, offset);
+		auto vmdkp = reinterpret_cast<::hyc::StordVmdk*>(handle);
+		return g_stord.VmdkRead(vmdkp, privatep, bufferp, buf_sz, offset);
 	} catch(std::exception& e) {
 		return kInvalidRequestID;
 	}
@@ -1097,7 +1063,8 @@ RequestID HycScheduleRead(VmdkHandle handle, const void* privatep,
 uint32_t HycGetCompleteRequests(VmdkHandle handle, RequestResult *resultsp,
 		uint32_t nresults, bool *has_morep) {
 	try {
-		return g_stord.VmdkGetCompleteRequest(handle, resultsp, nresults,
+		auto vmdkp = reinterpret_cast<::hyc::StordVmdk*>(handle);
+		return g_stord.VmdkGetCompleteRequest(vmdkp, resultsp, nresults,
 			has_morep);
 	} catch (const std::exception& e) {
 		*has_morep = true;
@@ -1108,7 +1075,8 @@ uint32_t HycGetCompleteRequests(VmdkHandle handle, RequestResult *resultsp,
 RequestID HycScheduleWrite(VmdkHandle handle, const void* privatep,
 		char* bufferp, int32_t buf_sz, int64_t offset) {
 	try {
-		return g_stord.VmdkWrite(handle, privatep, bufferp, buf_sz, offset);
+		auto vmdkp = reinterpret_cast<::hyc::StordVmdk*>(handle);
+		return g_stord.VmdkWrite(vmdkp, privatep, bufferp, buf_sz, offset);
 	} catch(std::exception& e) {
 		return kInvalidRequestID;
 	}
@@ -1117,8 +1085,9 @@ RequestID HycScheduleWrite(VmdkHandle handle, const void* privatep,
 RequestID HycScheduleWriteSame(VmdkHandle handle, const void* privatep,
 		char* bufferp, int32_t buf_sz, int32_t write_sz, int64_t offset) {
 	try {
-		return g_stord.VmdkWriteSame(handle, privatep, bufferp, buf_sz,
-			write_sz, offset);
+		auto vmdkp = reinterpret_cast<::hyc::StordVmdk*>(handle);
+		return g_stord.VmdkWriteSame(vmdkp, privatep, bufferp,
+			buf_sz, write_sz, offset);
 	} catch(std::exception& e) {
 		return kInvalidRequestID;
 	}

--- a/src/thrift-client/tests/TgtInterfaceImplTests.cpp
+++ b/src/thrift-client/tests/TgtInterfaceImplTests.cpp
@@ -32,7 +32,8 @@ public:
 	}
 
 	void async_tm_PushVmdkStats(std::unique_ptr<HandlerCallbackBase> cb,
-			VmdkHandle vmdk, std::unique_ptr<VmdkStats> stats) override {
+			::hyc_thrift::VmdkHandle vmdk, std::unique_ptr<VmdkStats> stats)
+			override {
 		++nstats_;
 	}
 
@@ -48,7 +49,8 @@ public:
 		++nclose_vm_;
 	}
 
-	void async_tm_OpenVmdk(std::unique_ptr<HandlerCallback<VmdkHandle>> cb,
+	void async_tm_OpenVmdk(
+			std::unique_ptr<HandlerCallback<::hyc_thrift::VmdkHandle>> cb,
 			std::unique_ptr<std::string> vmid,
 			std::unique_ptr<std::string> vmdkid) override {
 		cb->result(++vmdk_handle_);
@@ -56,15 +58,15 @@ public:
 	}
 
 	void async_tm_CloseVmdk(std::unique_ptr<HandlerCallback<int32_t>> cb,
-			VmdkHandle vmdk) override {
+			::hyc_thrift::VmdkHandle vmdk) override {
 		cb->result(0);
 		++nclose_vmdk_;
 	}
 
 	void async_tm_Read(
 			std::unique_ptr<HandlerCallback<std::unique_ptr<ReadResult>>> cb,
-			VmdkHandle vmdk, RequestId reqid, int32_t size, int64_t offset)
-			override {
+			::hyc_thrift::VmdkHandle vmdk, RequestId reqid, int32_t size,
+			int64_t offset) override {
 		auto iobuf = folly::IOBuf::create(size);
 		::memset(iobuf->writableTail(), 'A', size);
 		iobuf->append(size);
@@ -78,8 +80,9 @@ public:
 
 	void async_tm_Write(
 			std::unique_ptr<HandlerCallback<std::unique_ptr<WriteResult>>> cb,
-			VmdkHandle vmdk, RequestId reqid, std::unique_ptr<IOBufPtr> data,
-			int32_t size, int64_t offset) override {
+			::hyc_thrift::VmdkHandle vmdk, RequestId reqid,
+			std::unique_ptr<IOBufPtr> data, int32_t size, int64_t offset)
+			override {
 		auto write = std::make_unique<WriteResult>();
 		write->set_reqid(reqid);
 		write->set_result(0);
@@ -89,8 +92,9 @@ public:
 
 	void async_tm_WriteSame(
 			std::unique_ptr<HandlerCallback<std::unique_ptr<WriteResult>>> cb,
-			VmdkHandle vmdk, RequestId reqid, std::unique_ptr<IOBufPtr> data,
-			int32_t data_size, int32_t write_size, int64_t offset) override {
+			::hyc_thrift::VmdkHandle vmdk, RequestId reqid,
+			std::unique_ptr<IOBufPtr> data, int32_t data_size,
+			int32_t write_size, int64_t offset) override {
 		auto write = std::make_unique<WriteResult>();
 		write->set_reqid(reqid);
 		write->set_result(0);
@@ -110,7 +114,7 @@ public:
 	std::atomic<uint32_t> nstats_{0};
 private:
 	std::atomic<VmHandle> vm_handle_{0};
-	std::atomic<VmdkHandle> vmdk_handle_{0};
+	std::atomic<::hyc_thrift::VmdkHandle> vmdk_handle_{0};
 };
 
 static std::shared_ptr<ScopedServerInterfaceThread> StartServer() {
@@ -184,10 +188,10 @@ TEST(TgtInterfaceImplTest, Read) {
 	auto rc = HycStorRpcServerConnect();
 	EXPECT_EQ(rc, rc);
 
-	VmdkHandle handle = kInvalidVmdkHandle;
+	::VmdkHandle handle = nullptr;
 	rc = HycOpenVmdk("vmid", "vmdkid", -1, &handle);
 	EXPECT_EQ(rc, 0);
-	EXPECT_NE(handle, kInvalidVmdkHandle);
+	EXPECT_NE(handle, nullptr);
 
 	std::mutex mutex;
 	std::set<RequestID> scheduled;


### PR DESCRIPTION
We pass VmdkHandle as a number to TGTD. In IO code path,
the handle is mapped to StordVmdk. We can avoid this map
lookup completely by passing StordVmdk* as VmdkHandle
to TGTD.

Signed-off-by: Prasad Joshi <Prasad.Joshi@primaryio.com>