### PR TITLE
retry in case of failure in read path

### DIFF
--- a/src/thrift-client/TgtInterfaceImpl.cpp
+++ b/src/thrift-client/TgtInterfaceImpl.cpp
@@ -778,6 +778,9 @@ constexpr T GetErrNo(T arg1, Args... args) {
 void StordVmdk::RequestComplete(RequestID id, int32_t result) {
 	auto it = requests_.scheduled_.find(id);
 	log_assert(it != requests_.scheduled_.end());
+	if (result) {
+		LOG(ERROR) << "reqid " << id << " has nonzero res: " << result;
+	}
 
 	auto req = std::move(it->second);
 	auto reqp = req.get();
@@ -968,7 +971,7 @@ void StordVmdk::BulkReadComplete(const std::vector<Request*>& requests,
 		}
 		return nullptr;
 	};
-
+	reqp->result = result.result;
 	for (const auto& result : results) {
 		auto reqp = RequestFind(result.reqid);
 		if (hyc_likely(result.result == 0)) {

--- a/src/thrift-client/TgtInterfaceImpl.cpp
+++ b/src/thrift-client/TgtInterfaceImpl.cpp
@@ -779,7 +779,7 @@ void StordVmdk::RequestComplete(RequestID id, int32_t result) {
 	auto it = requests_.scheduled_.find(id);
 	log_assert(it != requests_.scheduled_.end());
 	if (result) {
-		LOG(ERROR) << "reqid " << id << " has nonzero res: " << result;
+		VLOG(5) << "reqid " << id << " has nonzero res: " << result;
 	}
 
 	auto req = std::move(it->second);
@@ -971,9 +971,9 @@ void StordVmdk::BulkReadComplete(const std::vector<Request*>& requests,
 		}
 		return nullptr;
 	};
-	reqp->result = result.result;
 	for (const auto& result : results) {
 		auto reqp = RequestFind(result.reqid);
+		reqp->result = result.result;
 		if (hyc_likely(result.result == 0)) {
 			log_assert(reqp != nullptr);
 			ReadDataCopy(reqp, result);


### PR DESCRIPTION
Retry would be attempted if nw msg is timed out at gateway. 
This won't help in another scenario where stord crash if we bring down aerospike node (1 out of 3/4) while boot happening. It would be fixed in hyc-storage-layer by sending down io request on-prem. 