### PR TITLE
Implemented DP-2123

### DIFF
--- a/src/include/TgtInterface.h
+++ b/src/include/TgtInterface.h
@@ -9,6 +9,28 @@ extern "C"  {
 #include <stdbool.h>
 #endif
 
+typedef struct vmdk_stats
+{
+	int64_t read_requests;
+	int64_t read_failed;
+	int64_t read_bytes;
+	int64_t read_latency;
+
+	int64_t write_requests;
+	int64_t write_failed;
+	int64_t write_same_requests;
+	int64_t write_same_failed;
+	int64_t write_bytes;
+	int64_t write_latency;
+
+	int64_t truncate_requests;
+	int64_t truncate_failed;
+	int64_t truncate_latency;
+
+	int64_t pending;
+	int64_t rpc_requests_scheduled;
+} vmdk_stats_t;
+
 void HycStorInitialize(int argc, char *argv[], char *stord_ip, uint16_t stord_port);
 int32_t HycStorRpcServerConnect(void);
 int32_t HycStorRpcServerDisconnect(void);
@@ -27,6 +49,7 @@ void HycDumpVmdk(VmdkHandle handle);
 void HycSetExpectedWanLatency(uint32_t latency);
 RequestID HycScheduleTruncate(VmdkHandle handle, const void* privatep,
 	char* bufferp, int32_t buf_sz);
+int HycGetVmdkStats(const char* vmdkid, vmdk_stats_t *vmdk_stats);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
vmdk_stats rest call will invoke this thrift code,
1. To find out a vmdk object for a given vmdkid
2. To fill out REST call vmdk_stats structure using found vmdk object

Test:
Tested a working functionality by invoking a curl command

Signed-off-by: Deepen Mehta <deepen.mehta@primaryio.com>