### PR TITLE
Stats rest call to study further adaptive batching for sandbox

### DIFF
--- a/src/include/TgtInterface.h
+++ b/src/include/TgtInterface.h
@@ -11,9 +11,12 @@ extern "C"  {
 
 typedef struct vmdk_stats
 {
-	int64_t rpc_requests_scheduled;
-	int64_t pending;
+	int64_t batchsize_decr;
+	int64_t batchsize_incr;
+	int64_t batchsize_same;
+	int64_t need_schedule_count;
 	int64_t stord_stats_pending;
+	int64_t avg_batchsize;
 } vmdk_stats_t;
 
 

--- a/src/include/TgtInterface.h
+++ b/src/include/TgtInterface.h
@@ -9,6 +9,15 @@ extern "C"  {
 #include <stdbool.h>
 #endif
 
+typedef struct vmdk_stats
+{
+	int64_t rpc_requests_scheduled;
+	int64_t pending;
+	int64_t stord_stats_pending;
+} vmdk_stats_t;
+
+
+
 void HycStorInitialize(int argc, char *argv[], char *stord_ip, uint16_t stord_port);
 int32_t HycStorRpcServerConnect(void);
 int32_t HycStorRpcServerDisconnect(void);
@@ -27,6 +36,7 @@ void HycDumpVmdk(VmdkHandle handle);
 void HycSetBatchingAttributes(uint32_t adaptive_batch, uint32_t wan_latency,
 		uint32_t batch_incr_val, uint32_t batch_decr_pct,
 		uint32_t system_load_factor, uint32_t debug_log);
+int HycGetVmdkStats(const char* vmdkid, vmdk_stats_t *vmdk_stats);
 #ifdef __cplusplus
 }
 #endif

--- a/src/thrift-client/TgtInterfaceImpl.cpp
+++ b/src/thrift-client/TgtInterfaceImpl.cpp
@@ -653,6 +653,8 @@ private:
 	static StordStats stord_stats_;
 
 	std::atomic<RequestID> requestid_{0};
+public:
+	std::mutex mutex_;
 };
 
 StordStats StordVmdk::stord_stats_;
@@ -751,6 +753,7 @@ int StordVmdk::CloseVmdk() {
 	if (vmdk_handle_ == kInvalidVmdkHandle) {
 		return 0;
 	}
+	std::lock_guard<std::mutex> lock(mutex_);
 
 	if (PendingOperations() != 0) {
 		LOG(ERROR) << "Close VMDK Failed" << *this;
@@ -1629,6 +1632,7 @@ int HycGetVmdkStats(const char* vmdkid, vmdk_stats_t *vmdk_stats) {
 		return -EINVAL;
 	}
 
+	std::lock_guard<std::mutex> lock(vmdkp->mutex_);
 	const ::hyc::VmdkStats& stats = vmdkp->GetVmdkStats();
 	vmdk_stats->stord_stats_pending = vmdkp->GetStordStats().pending_;
 	vmdk_stats->batchsize_decr = stats.batchsize_decr_;

--- a/src/thrift-client/TgtInterfaceImpl.cpp
+++ b/src/thrift-client/TgtInterfaceImpl.cpp
@@ -1626,14 +1626,16 @@ void HycSetBatchingAttributes(uint32_t adaptive_batch, uint32_t wan_latency,
 int HycGetVmdkStats(const char* vmdkid, vmdk_stats_t *vmdk_stats) {
 	::hyc::StordVmdk *vmdkp = g_stord.FindVmdk(std::string(vmdkid));
 	if (!vmdkp) {
-		LOG(ERROR) << "vmdk with id " << vmdkid << " is not found";
 		return -EINVAL;
 	}
 
 	const ::hyc::VmdkStats& stats = vmdkp->GetVmdkStats();
-	vmdk_stats->pending = stats.pending_;
 	vmdk_stats->stord_stats_pending = vmdkp->GetStordStats().pending_;
-	vmdk_stats->rpc_requests_scheduled = stats.rpc_requests_scheduled_;
+	vmdk_stats->batchsize_decr = stats.batchsize_decr_;
+	vmdk_stats->batchsize_incr = stats.batchsize_incr_;
+	vmdk_stats->batchsize_same = stats.batchsize_same_;
+	vmdk_stats->need_schedule_count = stats.need_schedule_count_;
+	vmdk_stats->avg_batchsize = stats.avg_batchsize_.Average();
 
 	return 0;
 }


### PR DESCRIPTION
Stats rest call to study further adaptive batching for sandbox.
Intentionally kept rest call function as get_vmdk_stats so that when we merge into master we will provide all these stats through same function.