### PR TITLE
DP-2795

### DIFF
--- a/src/include/Request.h
+++ b/src/include/Request.h
@@ -47,7 +47,7 @@ public:
 	char* bufferp;
 	int32_t buf_sz;
 	TimePoint timer;
-	RequestBase* sync_req;
+	RequestBase* sync_req{};
 	size_t batch_size;
 	SharedMemory::Handle shm_;
 

--- a/src/thrift-client/TgtInterfaceImpl.cpp
+++ b/src/thrift-client/TgtInterfaceImpl.cpp
@@ -769,6 +769,7 @@ private:
 	bool SyncRequestComplete(RequestID id, int32_t result);
 	void SyncRequestComplete(SyncRequest* reqp);
 
+	bool UpdateSyncRequest(Request* request, SyncRequest* sync) noexcept;
 	bool RequestComplete(RequestID id, int32_t result);
 	void RequestComplete(Request* reqp);
 
@@ -1062,6 +1063,7 @@ bool StordVmdk::PrepareRequest(std::unique_ptr<Request> request) {
 			overlapped_write = true;
 			prepared = false;
 			++stats_.sync_hold_new_writes_;
+			break;
 		}
 	}
 
@@ -1403,6 +1405,16 @@ void StordVmdk::UpdateBatchSize(Request* reqp) {
 	}
 }
 
+/*
+ * Handle Sync Request for completed Write request
+ */
+bool StordVmdk::UpdateSyncRequest(Request* request, SyncRequest* sync) noexcept {
+	request->sync_req = nullptr;
+	--stats_.sync_ongoing_writes_;
+	sync->result = 0;
+	return --sync->count == 0;
+}
+
 bool StordVmdk::RequestComplete(RequestID id, int32_t result) {
 	SyncRequest* syncp{nullptr};
 	bool post = false;
@@ -1427,12 +1439,8 @@ bool StordVmdk::RequestComplete(RequestID id, int32_t result) {
 	}
 
 	if (hyc_unlikely(reqp->sync_req and reqp->IsWrite())) {
-		SyncRequest *sync_reqp = reinterpret_cast<SyncRequest *>(reqp->sync_req);
-		--stats_.sync_ongoing_writes_;
-		if (!--sync_reqp->count) {
-			sync_reqp->result = 0;
-			syncp = sync_reqp;
-		}
+		SyncRequest *sync_req = reinterpret_cast<SyncRequest *>(reqp->sync_req);
+		syncp = UpdateSyncRequest(reqp, sync_req) ? sync_req : nullptr;
 	}
 
 	requests_.scheduled_.erase(it);
@@ -1939,6 +1947,16 @@ void StordVmdk::ScheduleNow(folly::EventBase* basep) {
 
 			std::lock_guard<std::mutex> lock(reqp->mutex_);
 			if (hyc_unlikely(reqp->privatep == nullptr)) {
+				if (reqp->IsWrite() and reqp->sync_req) {
+					auto sync = reinterpret_cast<SyncRequest *>(reqp->sync_req);
+					const bool complete = [this, reqp, sync] () mutable {
+							std::unique_lock<std::mutex> lock(requests_.mutex_);
+							return UpdateSyncRequest(reqp, sync);
+						} ();
+					if (complete) {
+						SyncRequestComplete(sync);
+					}
+				}
 				continue;
 			}
 			if (hyc_likely(static_cast<size_t>(reqp->buf_sz) <= kMaxBlockSize)) {

--- a/src/thrift-client/TgtInterfaceImpl.cpp
+++ b/src/thrift-client/TgtInterfaceImpl.cpp
@@ -1947,16 +1947,8 @@ void StordVmdk::ScheduleNow(folly::EventBase* basep) {
 
 			std::lock_guard<std::mutex> lock(reqp->mutex_);
 			if (hyc_unlikely(reqp->privatep == nullptr)) {
-				if (reqp->IsWrite() and reqp->sync_req) {
-					auto sync = reinterpret_cast<SyncRequest *>(reqp->sync_req);
-					const bool complete = [this, reqp, sync] () mutable {
-							std::unique_lock<std::mutex> lock(requests_.mutex_);
-							return UpdateSyncRequest(reqp, sync);
-						} ();
-					if (complete) {
-						SyncRequestComplete(sync);
-					}
-				}
+				reqp->result = -EIO;
+				RequestComplete(reqp);
 				continue;
 			}
 			if (hyc_likely(static_cast<size_t>(reqp->buf_sz) <= kMaxBlockSize)) {


### PR DESCRIPTION
   

There are two problems, here is description for first problem

Analysis based on a core file of TGT

A VMDK which had hunged IOs

```
(gdb) p $vmdk
$157 = (hyc::StordVmdk *) 0x2ebe7a0

```

It has 63 pending IOs 

`(gdb) p $vmdk->requests_.scheduled_$2 = std::unordered_map with 63 elements = {[37302] = std::unique_ptr <hyc::Request> containing 0x2e6de70,
`
It has 4 pending SYNC requests

    (gdb) p $vmdk->requests_.sync_pending_$3 = std::unordered_map with 4 elements = {

IDs of the pending SYNC request

    (gdb) p (( hyc::SyncRequest *) 0x3007de0 ) -> id
    $22 = 37288
    (gdb) p (( hyc::SyncRequest *) 0x3555f60 ) -> id
    $23 = 37256
    (gdb) p (( hyc::SyncRequest *) 0x2f06dd0 ) -> id
    $24 = 37126
    (gdb) p (( hyc::SyncRequest *) 0x2eb9590 ) -> id
    $25 = 37153

The first pending SYNC request is ‘37126’, it is pending for single IO to complete. 

    (gdb) p ((hyc::SyncRequest *) 0x2f06dd0 )->count
    $5 = 1

Now, after dumping data for all pending 63 requests.

===== FOLLOWING REQUEST IS THE CULPRIT ======

    (gdb) p * ( (hyc::Request *)  0x3007e90 )
    $159 = {id = 37101, type = hyc::RequestBase::Type::kWrite, privatep = 0x0, 
         length = 8192, offset = 3740110848, result = 0}

The privatep=0x0 is NULL and RequestID=37101

if privatep is NULL it indicates the the request is aborted. We can confirm this in STORD log as well. (for every aborted request TGT sends a RPC message to STORD. STORD only dumps the RPC).

First SYNC request is waiting for a single aborted request

Now there are two possibilities

This request (ID=37101) is either sent to STORD, in which case STORD has not responded to it.    OR

It was never sent to STORD

For every request we sent to STORD a timer is started, which waits for 60 seconds. If the STORD does not respond within that time frame the request is failed. The failed request is cleaned-up and iSCSI initiator is responded to with a failure. For request ID=37101 we never saw TIMEDOUT msg in TGT logs.

It means, the timer was never started and the request was never sent to STORD.

When can this happen?

There were IOs at TGT

iSCSI initiator issued ABORT and followed by a SYNC (first SYNC ID < 37101)

Before SYNC is complete, iSCSI initiator issued few more write commands (this time RequestID assigned is 37101)

Now the request is pending for existing SYNC to complete.

Unfortunately, existing SYNC takes time to complete. iSCSI initiator now aborts all pending requests (RequestID=37101) is aborted, and issues another SYNC (second SYNC with ID = 37126 (SYNC which is blocked))

Now the STORED responds to requests on which FIRST SYNC is waiting. We pickup all the requests blocked on first SYNC and try to send them to STORD.

Now in TGT side RPC code

    for (all pending requests) {
        if (hyc_unlikely(reqp->privatep == nullptr)) {
            /* Aborted Request - ignore it */
            continue;
        }

The problem her is at line 3-4 above, basically we are silently ignoring the request.

The fix is to ensure Request is cleanedup properly

    for (all pending requests) {
        if (hyc_unlikely(reqp->privatep == nullptr)) {
            reqp->result = -EIO;
            RequestComplete(reqp);
            continue;
        }

After the Request is cleanedup, the SYNC request too will cleanup, and we will make progress.


   

The second problem

TGT dumps following information for every VMDK. During one of the debugging session, we saw dumps like following

> I0414 20:00:42.851742 20 TgtInterfaceImpl.cpp:441] VmID=vm-1389 VmdkID=272 VmdkHandle=2 eventfd=25 requestid=38752 pending=95 batchsize-avg=15 latency-avg=12216 Bulk-IODepth-avg=1 Req-Sched=3421 Req-Rpc-Qed=0 Req-Sync-Pending=387 Req-Pending-On-Sync=567345

- Req-Sync-Pending = 387 → this is number of SYNC requests pending
- Req-Pending-On-Sync=567345 → this is number of requests pending on SYNC to complete
- Req-Sched is 3421 → this is number of requests in the system

If there are only 3421 requests in the system, when is Req-Pending-On-Sync=567345. It probably, means the counter 

is incremented multiple times for a single request    OR

counter is not decremented OR

some race.

The corresponding counter in the code is 

`VMDK->stats_.sync_ongoing_writes_`

This is a ATOMIC variable - no chance of race

the counter is decremented at correct place. 

The problem is following code

```
bool PrepareSyncRequest(SyncRequest* nreqp) {
    for (for every request) {
        switch (req_ptr->type) {
        case Request::Type::kWrite:
            if (not req_ptr->IsOverlapped(nreqp->offset, nreqp->length)) {
                continue;
            }
            req_ptr->sync_req = nreqp;
            ++nreqp->count;
            ++stats_.sync_ongoing_writes_;
            complete = false;
            break;
        }
    }
```

This function is called for every SYNC request

at line 2, 3, 4 - we are going through all WRITE REQUESTs in the system

at line 5 - we check offset of both SYNC and Write Request overlap.

at line 8 - If they do, we associate SYNC request with Write Request

At line 9 - we increment SYNC request count.

I think, the line 5, where we check if both SYNC request and Write Request overlap, has a problem. We should only check requests which are not already associated with any SYNC request.

At line 8 we are overwriting the reqp_ptr->sync_req pointer. Before overwriting the pointer, we should ensure it is NULL. If it is not NULL, which means a request is already associated with existing SYNC request.

